### PR TITLE
Use larger blocksize with bwa index on >100MB files

### DIFF
--- a/NGLess.cabal.m4
+++ b/NGLess.cabal.m4
@@ -91,6 +91,7 @@ define(`BASE_CONFIG',
       unix
   if !flag(Embed)
     CC-Options: -DNO_EMBED_SAMTOOLS_BWA
+    cpp-options: -DNO_EMBED_SAMTOOLS_BWA
 ')
 
 executable ngless

--- a/NGLess/Configuration.hs
+++ b/NGLess/Configuration.hs
@@ -13,6 +13,7 @@ module Configuration
     , bwaBin
     , versionStr
     , compilationDateStr
+    , embeddedStr
     , dateStr
     , setQuiet
     ) where
@@ -50,6 +51,13 @@ dateStr = "not released"
 
 compilationDateStr :: String
 compilationDateStr = __DATE__
+
+embeddedStr :: String
+#ifdef NO_EMBED_SAMTOOLS_BWA
+embeddedStr = "No"
+#else
+embeddedStr = "Yes"
+#endif
 
 defaultBaseURL :: FilePath
 defaultBaseURL = "http://vm-lux.embl.de/~coelho/ngless-data/"

--- a/NGLess/FileManagement.hs
+++ b/NGLess/FileManagement.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 module FileManagement
     ( createTempDir
+    , getFileSize
     , openNGLTempFile
     , openNGLTempFile'
     , removeFileIfExists
@@ -16,6 +17,7 @@ import qualified Data.ByteString as BS
 import System.FilePath
 import Control.Monad
 import System.Posix.Internals (c_getpid)
+import System.Posix (getFileStatus, fileSize, FileOffset)
 
 import Data.FileEmbed (embedDir)
 import Output
@@ -119,3 +121,6 @@ copyDir src dst = do
     if exists
         then copyDir  (src </> n) (dst </> n)
         else copyFile (src </> n) (dst </> n)
+
+getFileSize :: FilePath -> IO FileOffset
+getFileSize path = fileSize <$> getFileStatus path

--- a/NGLess/Main.hs
+++ b/NGLess/Main.hs
@@ -229,14 +229,14 @@ modeExec (DownloadFileMode url local) = runNGLessIO "download a file" $
 
 main = do
     let metainfo = fullDesc <> footer foottext <> progDesc "ngless implement the NGLess language"
-        foottext = concat ["ngless v", versionStr, "(C) NGLess Authors 2013-2016"]
+        foottext = concat ["ngless v", versionStr, "(C) NGLess Authors 2013-2017"]
         versioner =
             (infoOption ("ngless v" ++ versionStr ++ " (release date: " ++  dateStr ++ ")")
                 (long "version" <> short 'V' <> help "print version and exit"))
             <*>
             (infoOption versionStr (long "version-short" <> help "print just version string (useful for scripting)"))
             <*>
-            (infoOption ("ngless v" ++ versionStr ++ " (release date: " ++  dateStr ++ "; compilation date: " ++ compilationDateStr ++ ")")
+            (infoOption ("ngless v" ++ versionStr ++ " (release date: " ++  dateStr ++ "; compilation date: " ++ compilationDateStr ++ "; embedded binaries: " ++ embeddedStr ++ ")")
                 (long "version-debug" <> help "print detailed version information"))
             <*>
             (infoOption dateStr (long "date-short" <> help "print just release date string (useful for scripting)"))

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -112,6 +112,13 @@ for testdir in tests/*; do
                 ok=no
             fi
         fi
+
+        if test $ok = "no"; then
+            echo "ERROR: Output from from ngless was:"
+            cat output.stdout.txt
+            cat output.stderr.txt
+        fi
+
         if test -x ./cleanup.sh; then
             ./cleanup.sh
         fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -56,6 +56,8 @@ if ! test -x $ngless_bin ; then
     exit 1
 fi
 
+echo "Running with: $($ngless_bin --version-debug)"
+
 basedir=$REPO
 for testdir in tests/*; do
     if test -d $testdir; then

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,6 +11,7 @@ function remove_ngless_bin {
 # This script is located on the root of the repository
 # where samtools and bwa are also compiled
 REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo ">>> Using repository at $REPO <<<"
 
 if [[ "$0" == *-embedded.sh ]]; then
     echo ">>> Testing NGLess ( with embedded binaries ) <<<"
@@ -24,6 +25,8 @@ else
     echo ">>> Testing NGLess ( regular build ) <<<"
     export NGLESS_SAMTOOLS_BIN=$REPO/samtools-1.3.1/samtools
     export NGLESS_BWA_BIN=$REPO/bwa-0.7.15/bwa
+    echo ">> Will use samtools from '$NGLESS_SAMTOOLS_BIN' <<"
+    echo ">> Will use bwa from '$NGLESS_BWA_BIN' <<"
     MAKETARGET=""
 fi
 
@@ -48,6 +51,15 @@ if [ "$MAKETARGET" != "" ]; then
         echo "ERROR IN 'make $MAKETARGET'"
         ok=no
     fi
+else
+    if ! test -x $NGLESS_SAMTOOLS_BIN ; then
+        echo "ERROR: samtools not found at '$NGLESS_SAMTOOLS_BIN'"
+        exit 1
+    fi
+    if ! test -x $NGLESS_BWA_BIN ; then
+        echo "ERROR: bwa not found at '$NGLESS_BWA_BIN'"
+        exit 1
+    fi
 fi
 
 ngless_bin=$(stack path --local-install-root)/bin/ngless
@@ -56,7 +68,7 @@ if ! test -x $ngless_bin ; then
     exit 1
 fi
 
-echo "Running with: $($ngless_bin --version-debug)"
+echo ">>> Running with: $($ngless_bin --version-debug) <<<"
 
 basedir=$REPO
 for testdir in tests/*; do


### PR DESCRIPTION
This reduces CPU time required for indexing drastically at the expense of higher memory usage.

The same machine that will run `bwa mem` should be able to accommodate this without problems.