### PR TITLE
Fix samtools tests and add ability to test command line arguments 

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -84,7 +84,11 @@ for testdir in tests/*; do
         if [[ $testdir == tests/error-validation-* ]] ; then
             validate_arg="-n"
         fi
-        $ngless_bin --quiet -t temp $validate_arg *.ngl > output.stdout.txt 2>output.stderr.txt
+        cmd_args=""
+        if test -f ${testdir}/cmdargs ; then
+            cmd_args="$(cat ${testdir}/cmdargs)"
+        fi
+        $ngless_bin --quiet -t temp $cmd_args $validate_arg *.ngl > output.stdout.txt 2>output.stderr.txt
         ngless_exit=$?
         if [[ $testdir == tests/error-* ]] ; then
             if test $ngless_exit -eq "0"; then

--- a/tests/samfile-select-sort/check.sh
+++ b/tests/samfile-select-sort/check.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
-if ! diff <(samtools view -h output.bam) texpected.sam ; then
+if [ "$(which samtools 2>/dev/null)" == "" ]; then
+    SAMTOOLS="$NGLESS_SAMTOOLS_BIN"
+else
+    SAMTOOLS="$(which samtools)"
+fi
+
+if ! diff <($SAMTOOLS view -h output.bam) texpected.sam ; then
     exit 1
 fi

--- a/tests/samfile-write/check.sh
+++ b/tests/samfile-write/check.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
-if ! diff <(samtools view -h output.bam) texpected.sam ; then
+if [ "$(which samtools 2>/dev/null)" == "" ]; then
+    SAMTOOLS="$NGLESS_SAMTOOLS_BIN"
+else
+    SAMTOOLS="$(which samtools)"
+fi
+
+if ! diff <($SAMTOOLS view -h output.bam) texpected.sam ; then
     exit 1
 fi

--- a/tests/select-bam/check.sh
+++ b/tests/select-bam/check.sh
@@ -1,8 +1,14 @@
 #!/usr/bin/env bash
 
-if ! diff <(samtools view output.neg.bam) texpected.neg.sam ; then
+if [ "$(which samtools 2>/dev/null)" == "" ]; then
+    SAMTOOLS="$NGLESS_SAMTOOLS_BIN"
+else
+    SAMTOOLS="$(which samtools)"
+fi
+
+if ! diff <($SAMTOOLS view output.neg.bam) texpected.neg.sam ; then
     exit 1
 fi
-if ! diff <(samtools view output.plus.bam) texpected.plus.sam ; then
+if ! diff <($SAMTOOLS view output.plus.bam) texpected.plus.sam ; then
     exit 1
 fi


### PR DESCRIPTION
Fixes running samtools tests on a system without 'samtools' in $PATH.

It also expands the parallel test to cover the use-case described in #17 