### PR TITLE
Fix issues with building and testing a static binary

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+build-and-test:
+    image: alpine:edge
+    stage: build
+
+    before_script:
+    - echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
+    - apk update
+    - apk add alpine-sdk bash bzip2-dev ca-certificates cabal@testing file
+        ghc-dev@testing ghc@testing git gmp-dev libffi-dev libgcc
+        linux-headers m4 make py2-pip python2 python2-dev vim xz xz-dev
+        zlib-dev
+
+    - wget -qO- https://get.haskellstack.org/ | sh
+    - chmod 755 /usr/local/bin/stack
+    - pip install tox
+    - mkdir bin
+
+    script:
+    - STACKOPTS="--system-ghc" ./run-tests-static.sh
+    - stack --local-bin-path bin install --system-ghc --ghc-options '-optl-static -optl-pthread' --flag NGLess:embed
+
+    artifacts:
+        when: on_success
+        paths:
+        - bin/ngless
+        - Modules/packages/
+        expire_in: 1 month

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk update && apk add \
     gmp-dev \
     libffi-dev \
     libgcc \
+    linux-headers \
     m4 \
     make \
     vim \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ RUN mkdir -p /usr/src/
 RUN git clone --depth=10 https://github.com/luispedro/ngless /usr/src/ngless
 WORKDIR /usr/src/ngless
 
-RUN m4 NGLess.cabal.m4 > NGLess.cabal
-
 # This will have all make calls use the ghc installed above
 # Build dependencies in a separate step to avoid a full rebuild on ngless compile failure
 ENV STACKOPTS="--system-ghc --only-dependencies"
@@ -42,4 +40,4 @@ RUN make ngless-embed
 
 ENV STACKOPTS="--system-ghc"
 RUN make static
-RUN make install
+RUN stack --local-bin-path /usr/local/bin install $STACKOPTS --ghc-options '-optl-static -optl-pthread' --flag NGLess:embed

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ $(HTML_FONTS_DIR)/%.ttf:
 
 ngless-${VERSION}.tar.gz: ngless
 	mkdir -p $(distdir)/share $(distdir)/bin
-	stack build
+	stack build $(STACKOPTS)
 	cp dist/build/$(progname)/$(progname) $(distdir)/bin
 	cp -r $(BWA_DIR) $(distdir)/share
 	cp -r $(SAM_DIR) $(distdir)/share

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ NGLESS_EMBEDDED_BINARIES := \
 		NGLess/Dependencies/samtools_data.c \
 		NGLess/Dependencies/bwa_data.c \
 		NGLess/Dependencies/megahit_data.c
+NGLESS_EMBEDDED_TARGET = NGLess/Dependencies/embedded.c
 
 MEGAHIT_BINS := $(MEGAHIT_DIR)/megahit_asm_core $(MEGAHIT_DIR)/megahit_sdbg_build $(MEGAHIT_DIR)/megahit_toolkit $(MEGAHIT_DIR)/megahit
 NGLESS_EXT_BINS = $(BWA_DIR)/$(BWA_TARGET) $(SAM_DIR)/$(SAM_TARGET) $(MEGAHIT_BINS)
@@ -81,7 +82,7 @@ all: ngless
 NGLess.cabal: NGLess.cabal.m4
 	m4 $< > $@
 
-ngless-embed: NGLess.cabal $(NGLESS_EMBEDDED_BINARIES)
+ngless-embed: NGLess.cabal $(NGLESS_EMBEDDED_TARGET)
 	stack build $(STACKOPTS) --flag NGLess:embed
 
 ngless: NGLess.cabal
@@ -90,7 +91,7 @@ ngless: NGLess.cabal
 modules:
 	cd Modules && $(MAKE)
 
-static: NGLess.cabal $(NGLESS_EMBEDDED_BINARIES)
+static: NGLess.cabal $(NGLESS_EMBEDDED_TARGET)
 	stack build $(STACKOPTS) --ghc-options='-optl-static -optl-pthread' --force-dirty --flag NGLess:embed
 
 fast: NGLess.cabal
@@ -130,6 +131,9 @@ distclean: clean
 	rm -rf $(BWA_DIR)
 	rm -rf $(SAM_DIR)
 	rm -rf $(MEGAHIT_DIR)
+
+$(NGLESS_EMBEDDED_TARGET): $(NGLESS_EMBEDDED_BINARIES)
+	touch $(NGLESS_EMBEDDED_TARGET)
 
 $(BWA_DIR_TARGET):
 	wget $(BWA_URL)

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,7 +2,7 @@
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
 
-resolver: lts-7.12
+resolver: lts-8.13
 compiler-check: newer-minor
 
 

--- a/tests/samfile-select-sort/check.sh
+++ b/tests/samfile-select-sort/check.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 if [ "$(which samtools 2>/dev/null)" == "" ]; then
-    SAMTOOLS="$NGLESS_SAMTOOLS_BIN"
+    if [ "$NGLESS_SAMTOOLS_BIN" == "" ]; then
+        SAMTOOLS="$(ngless --print-path samtools)"
+    else
+        SAMTOOLS="$NGLESS_SAMTOOLS_BIN"
+    fi
 else
     SAMTOOLS="$(which samtools)"
 fi

--- a/tests/samfile-write/check.sh
+++ b/tests/samfile-write/check.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 if [ "$(which samtools 2>/dev/null)" == "" ]; then
-    SAMTOOLS="$NGLESS_SAMTOOLS_BIN"
+    if [ "$NGLESS_SAMTOOLS_BIN" == "" ]; then
+        SAMTOOLS="$(ngless --print-path samtools)"
+    else
+        SAMTOOLS="$NGLESS_SAMTOOLS_BIN"
+    fi
 else
     SAMTOOLS="$(which samtools)"
 fi

--- a/tests/select-bam/check.sh
+++ b/tests/select-bam/check.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
 if [ "$(which samtools 2>/dev/null)" == "" ]; then
-    SAMTOOLS="$NGLESS_SAMTOOLS_BIN"
+    if [ "$NGLESS_SAMTOOLS_BIN" == "" ]; then
+        SAMTOOLS="$(ngless --print-path samtools)"
+    else
+        SAMTOOLS="$NGLESS_SAMTOOLS_BIN"
+    fi
 else
     SAMTOOLS="$(which samtools)"
 fi


### PR DESCRIPTION
Also provide a gitlab testing file which will allow us to use the gitlab infrastructure to have an additional docker based test layer and automatically build a usable static binary.

The idea is to have https://gitlab.com/ngless/ngless/ which simply clones from github and builds.
All activity is still centered on github.