### PR TITLE
Build ngless nighlies on Ubuntu (glibc instead of muslc)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,37 @@
-build-and-test:
-    image: alpine:edge
+build-and-test-ubuntu:
+    image: registry.gitlab.com/ngless/ngless/ubuntu-ghc-stack:rolling
     stage: build
 
     before_script:
-    - echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
-    - apk update
-    - apk add alpine-sdk bash bzip2-dev ca-certificates cabal@testing file
-        ghc-dev@testing ghc@testing git gmp-dev libffi-dev libgcc
-        linux-headers m4 make py2-pip python2 python2-dev vim xz xz-dev
-        zlib-dev
+    - apt update
+    - apt upgrade -y
+    - stack upgrade
+    - mkdir bin
+    # Needed for tests that print UTF8 characters such as motus
+    # Same issue as https://github.com/commercialhaskell/stack/issues/793
 
-    - wget -qO- https://get.haskellstack.org/ | sh
-    - chmod 755 /usr/local/bin/stack
-    - pip install tox
+    variables:
+        LC_ALL: "C.UTF-8"
+
+    script:
+    - STACKOPTS="--system-ghc" ./run-tests-static.sh
+    - stack --local-bin-path bin install --system-ghc --ghc-options '-optl-static -optl-pthread' --flag NGLess:embed
+
+    artifacts:
+        when: on_success
+        paths:
+        - bin/ngless
+        - Modules/packages/
+        expire_in: 1 month
+
+build-and-test-alpine:
+    image: registry.gitlab.com/ngless/ngless/alpine-ghc-stack:edge
+    stage: build
+
+    before_script:
+    - apk update
+    - apk upgrade
+    - stack upgrade
     - mkdir bin
 
     script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ build-and-test-ubuntu:
 
     script:
     - STACKOPTS="--system-ghc" ./run-tests-static.sh
-    - stack --local-bin-path bin install --system-ghc --ghc-options '-optl-static -optl-pthread' --flag NGLess:embed
+    - stack --local-bin-path bin install --system-ghc --ghc-options '-fPIC' --flag NGLess:embed
 
     artifacts:
         when: on_success
@@ -36,7 +36,7 @@ build-and-test-alpine:
 
     script:
     - STACKOPTS="--system-ghc" ./run-tests-static.sh
-    - stack --local-bin-path bin install --system-ghc --ghc-options '-optl-static -optl-pthread' --flag NGLess:embed
+    - stack --local-bin-path bin install --system-ghc --ghc-options '-fPIC' --flag NGLess:embed
 
     artifacts:
         when: on_success

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ WORKDIR /usr/src/ngless
 # This will have all make calls use the ghc installed above
 # Build dependencies in a separate step to avoid a full rebuild on ngless compile failure
 ENV STACKOPTS="--system-ghc --only-dependencies"
-RUN make ngless-embed
+RUN make static
 
 ENV STACKOPTS="--system-ghc"
 RUN make static

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,6 @@ all: ngless
 NGLess.cabal: NGLess.cabal.m4
 	m4 $< > $@
 
-ngless-embed: NGLess.cabal $(NGLESS_EMBEDDED_TARGET)
-	stack build $(STACKOPTS) --flag NGLess:embed
-
 ngless: NGLess.cabal
 	stack build $(STACKOPTS)
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ modules:
 	cd Modules && $(MAKE)
 
 static: NGLess.cabal $(NGLESS_EMBEDDED_TARGET)
-	stack build $(STACKOPTS) --ghc-options='-optl-static -optl-pthread' --force-dirty --flag NGLess:embed
+	stack build $(STACKOPTS) --ghc-options='-fPIC' --force-dirty --flag NGLess:embed
 
 fast: NGLess.cabal
 	stack build $(STACKOPTS) --ghc-options=-O0

--- a/NGLess.cabal.m4
+++ b/NGLess.cabal.m4
@@ -169,6 +169,8 @@ define(`BASE_CONFIG',
   if !flag(Embed)
     CC-Options: -DNO_EMBED_SAMTOOLS_BWA
     cpp-options: -DNO_EMBED_SAMTOOLS_BWA
+  else
+    ld-options: -static -pthread
 ')
 
 executable ngless

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ versions for all these channels.
 ### Linux
 
 You can get an [unreleased statically linked version of
-NGless](http://vm-lux.embl.de/~coelho/ngless-data/releases/ngless-0.0.0-unreleased-Linux64) or a [nighly build of the latest development code](https://gitlab.com/ngless/ngless/builds/artifacts/master/raw/bin/ngless?job=build-and-test).
+NGless](http://vm-lux.embl.de/~coelho/ngless-data/releases/ngless-0.0.0-unreleased-Linux64) or a [nighly build of the latest development code](https://gitlab.com/ngless/ngless/builds/artifacts/master/raw/bin/ngless?job=build-and-test-ubuntu).
 This should work across a wide range of Linux versions (please
 [report](https://github.com/luispedro/ngless/issues) any issues you encounter):
 
@@ -49,9 +49,9 @@ This should work across a wide range of Linux versions (please
     chmod +x ngless-0.0.0-unreleased-Linux64
     ./ngless-0.0.0-unreleased-Linux64
 
-This download bundles bwa and samtools (also statically linked).
+This download bundles bwa, samtools and megahit (also statically linked).
 
-If you want to try one of ngless' builtin modules (motus, specI, ...) you can download [the full nighly build zip file](https://gitlab.com/ngless/ngless/builds/artifacts/master/download?job=build-and-test) which includes them.
+If you want to try one of ngless' builtin modules (motus, specI, ...) you can download [the full nighly build zip file](https://gitlab.com/ngless/ngless/builds/artifacts/master/download?job=build-and-test-ubuntu) which includes them.
 
 ### Brew
 

--- a/build-scripts/docker_bases/alpine/Dockerfile
+++ b/build-scripts/docker_bases/alpine/Dockerfile
@@ -1,0 +1,38 @@
+FROM alpine:edge
+
+LABEL maintainer "alves.rjc+docker@gmail.com"
+
+RUN echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
+    apk --no-cache add \
+    alpine-sdk \
+    bash \
+    bzip2-dev \
+    ca-certificates \
+    cabal@testing \
+    file \
+    ghc-dev@testing \
+    ghc@testing \
+    git \
+    gmp-dev \
+    libffi-dev \
+    libgcc \
+    linux-headers \
+    m4 \
+    make \
+    py2-pip \
+    python2 \
+    python2-dev \
+    vim \
+    xz \
+    xz-dev \
+    zlib-dev && \
+    wget -qO- https://get.haskellstack.org/ | sh && \
+    chmod 755 /usr/local/bin/stack && \
+    pip install tox
+
+# Build ngless dependencies to save time during build
+RUN git clone https://gitlab.com/ngless/ngless && \
+    cd ngless && \
+    STACKOPTS="--system-ghc --only-dependencies" make ngless && \
+    cd .. && \
+    rm -rf ngless

--- a/build-scripts/docker_bases/alpine/build.sh
+++ b/build-scripts/docker_bases/alpine/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -t registry.gitlab.com/ngless/ngless/alpine-ghc-stack:edge .

--- a/build-scripts/docker_bases/alpine/upload.sh
+++ b/build-scripts/docker_bases/alpine/upload.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker push registry.gitlab.com/ngless/ngless/alpine-ghc-stack:edge

--- a/build-scripts/docker_bases/ubuntu/Dockerfile
+++ b/build-scripts/docker_bases/ubuntu/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:rolling
+
+LABEL maintainer "alves.rjc+docker@gmail.com"
+
+RUN apt update && \
+    apt install -y \
+    build-essential \
+    cabal-install \
+    curl \
+    ghc \
+    git \
+    libbz2-dev \
+    liblzma-dev \
+    m4 \
+    python-dev \
+    python-pip \
+    wget \
+    xxd \
+    xz-utils \
+    zlib1g-dev && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists && \
+    wget -qO- https://get.haskellstack.org/ | sh && \
+    chmod 755 /usr/local/bin/stack && \
+    pip install tox
+
+# Build ngless dependencies to save time during build
+RUN git clone https://gitlab.com/ngless/ngless && \
+    cd ngless && \
+    STACKOPTS="--system-ghc --only-dependencies" make ngless && \
+    cd .. && \
+    rm -rf ngless

--- a/build-scripts/docker_bases/ubuntu/build.sh
+++ b/build-scripts/docker_bases/ubuntu/build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker build -t registry.gitlab.com/ngless/ngless/ubuntu-ghc-stack:rolling .

--- a/build-scripts/docker_bases/ubuntu/upload.sh
+++ b/build-scripts/docker_bases/ubuntu/upload.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+docker push registry.gitlab.com/ngless/ngless/ubuntu-ghc-stack:rolling

--- a/run-tests-embedded.sh
+++ b/run-tests-embedded.sh
@@ -1,1 +1,0 @@
-run-tests.sh

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,10 +21,7 @@ function remove_ngless_bin {
 REPO="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo ">>> Using repository at $REPO <<<"
 
-if [[ "$0" == *-embedded.sh ]]; then
-    echo ">>> Testing NGLess ( with embedded binaries ) <<<"
-    MAKETARGET="ngless-embed"
-elif [[ "$0" == *-static.sh ]]; then
+if [[ "$0" == *-static.sh ]]; then
     echo ">>> Testing NGLess ( static build with embedded binaries ) <<<"
     MAKETARGET="static"
 else


### PR DESCRIPTION
I recently ran into an issue with the bwa binary bundled with ngless which was compiled on alpine linux (muslc). The symptom is an "Out of memory" error and happens regardless of how much free memory the machine has. The actual amount of memory being allocated (or reallocated) varies but is frequently 256 bytes. Usually small numbers.

Retrying the same command would sometimes fail on a different code path resulting in slightly different error messages and tracebacks but always resulting in "Out of memory". It also took over 8 hours on average to trigger the error and only when using a large database (20GB+). Writing a test for this scenario is unfeasible.

Monitoring memory did not reveal any spike or strange usage.

At this point I'm convinced the error is _falsely_ showing the "Out of memory" message. I got as far as tracing it to a call to the memory allocation machinery (malloc). Discussing the issue with some alpine maintainers/users lead to blaming muslc. Possibly a hard to trace bug since there aren't many causes for an malloc failure.

Using a static version compiled against glibc did not trigger the error.

For this reason, this pull request now adds support to building on Ubuntu in addition to Alpine.

A few changes were also included that affect how the static binary is created. Without them I couldn't get a stable static binary. Workarounds such as [this](https://bugs.launchpad.net/ubuntu/+source/gcc-4.4/+bug/640734/comments/6) produced a binary but would lead to SIGABRT during execution.

Compilation of a static binary against glibc leads to warnings with code that makes use of name resolution (DNS) which is the case for both bwa and ngless. These static binaries may not work on non-glibc systems (not tested).