### PR TITLE
ENH Change in hashes for collect statements

### DIFF
--- a/NGLess/Main.hs
+++ b/NGLess/Main.hs
@@ -211,6 +211,7 @@ modeExec opts@DefaultMode{} = do
     (shouldOutput,odir) <- runNGLessIO "loading and running script" $ do
         updateNglEnvironment (\e -> e { ngleScriptText = ngltext })
         sc' <- runNGLess $ parsengless fname reqversion ngltext >>= maybe_add_print
+        updateNglEnvironment (\e -> e {ngleVersion = (nglVersion $ fromJust $ nglHeader sc')})
         when (debug_mode opts == "ast") $ liftIO $ do
             forM_ (nglBody sc') $ \(lno,e) ->
                 putStrLn ((if lno < 10 then " " else "")++show lno++": "++show e)

--- a/NGLess/Main.hs
+++ b/NGLess/Main.hs
@@ -211,7 +211,9 @@ modeExec opts@DefaultMode{} = do
     (shouldOutput,odir) <- runNGLessIO "loading and running script" $ do
         updateNglEnvironment (\e -> e { ngleScriptText = ngltext })
         sc' <- runNGLess $ parsengless fname reqversion ngltext >>= maybe_add_print
-        updateNglEnvironment (\e -> e {ngleVersion = (nglVersion $ fromJust $ nglHeader sc')})
+        updateNglEnvironment (\e -> e {ngleVersion = case (nglHeader sc') of
+            Nothing -> T.pack versionStr
+            Just header -> nglVersion header})
         when (debug_mode opts == "ast") $ liftIO $ do
             forM_ (nglBody sc') $ \(lno,e) ->
                 putStrLn ((if lno < 10 then " " else "")++show lno++": "++show e)

--- a/NGLess/NGLess/NGLEnvironment.hs
+++ b/NGLess/NGLess/NGLEnvironment.hs
@@ -23,7 +23,8 @@ import Configuration
 import CmdArgs
 
 data NGLEnvironment = NGLEnvironment
-                    { ngleScriptText :: !T.Text -- ^ The original text of the script
+                    { ngleVersion :: !T.Text
+                    , ngleScriptText :: !T.Text -- ^ The original text of the script
                     , ngleMappersActive :: [T.Text] -- ^ which mappers can be used
                     , ngleTemporaryFilesCreated :: [FilePath] -- ^ list of temporary files created
                     , ngleConfiguration :: NGLessConfiguration
@@ -31,7 +32,7 @@ data NGLEnvironment = NGLEnvironment
 
 ngle :: IORef NGLEnvironment
 {-# NOINLINE ngle #-}
-ngle = unsafePerformIO (newIORef $ NGLEnvironment "" ["bwa"] [] (error "Configuration not set"))
+ngle = unsafePerformIO (newIORef $ NGLEnvironment "" "" ["bwa"] [] (error "Configuration not set"))
 
 nglEnvironment :: NGLessIO NGLEnvironment
 nglEnvironment = liftIO $ readIORef ngle


### PR DESCRIPTION
-> ngless version added to the environment
-> hashes for collect dependent only on relevant part of the script body
-> version information is included in the hash of collect (versions of all modules, not only relevant ones)

Please review and have mercy.